### PR TITLE
AWS Provider 5.0 upgrade

### DIFF
--- a/test/lambda_test.go
+++ b/test/lambda_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestS3Creation(t *testing.T) {
+func TestLambdaCreation(t *testing.T) {
 	t.Parallel()
 
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{

--- a/test/unit-test/versions.tf
+++ b/test/unit-test/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 4.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 4.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
   }


### PR DESCRIPTION
Bumps version constraint to ~> 5.0.
Correct name of test function
Related to https://github.com/ministryofjustice/modernisation-platform/issues/4173