### PR TITLE
add invoke_arn lambda function output

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,5 +105,6 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_lambda_function_arn"></a> [lambda\_function\_arn](#output\_lambda\_function\_arn) | The ARN of the Lambda Function |
+| <a name="output_lambda_function_invoke_arn"></a> [lambda\_function\_invoke\_arn](#output\_lambda\_function\_invoke\_arn) | The invoke ARN of the Lambda Function |
 | <a name="output_lambda_function_name"></a> [lambda\_function\_name](#output\_lambda\_function\_name) | The Name of the Lambda Function |
 <!-- END_TF_DOCS -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "lambda_function_arn" {
   value       = try(aws_lambda_function.this.arn, "")
 }
 
+output "lambda_function_invoke_arn" {
+  description = "The invoke ARN of the Lambda Function"
+  value       = try(aws_lambda_function.this.invoke_arn, "")
+}
+
 output "lambda_function_name" {
   description = "The Name of the Lambda Function"
   value       = try(aws_lambda_function.this.function_name, "")


### PR DESCRIPTION
The invoke_arn is required when using the lambda function as an integration for an API Gateway.

See [here](https://registry.terraform.io/providers/hashicorp/aws/3.47.0/docs/resources/lambda_function#invoke_arn) and [here](https://registry.terraform.io/providers/hashicorp/aws/3.47.0/docs/resources/api_gateway_integration#uri)