### PR TITLE
Introducing destinations in lambda function

### DIFF
--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: terraform-linters/setup-tflint@19a52fbac37dacb22a09518e4ef6ee234f2d4987 # v4.0.0
         name: Setup TFLint
         with:
-          tflint_version: latest
+          tflint_version: v0.44.1
       - name: Init TFLint
         run: tflint --init
       - name: Run TFLint

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -19,16 +19,16 @@ jobs:
           - ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           fetch-depth: 0
       - name: Cache plugin dir
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
           path: ~/.tflint.d/plugins
           key: '${{ matrix.os }}-tflint-${{ hashFiles(''.tflint.hcl'') }}'
-      - uses: terraform-linters/setup-tflint@ba6bb2989f94daf58a4cc6eac2c1ca7398a678bf # v3.0.0
+      - uses: terraform-linters/setup-tflint@19a52fbac37dacb22a09518e4ef6ee234f2d4987 # v4.0.0
         name: Setup TFLint
         with:
           tflint_version: latest
@@ -38,7 +38,7 @@ jobs:
         run: tflint --disable-rule=terraform_unused_declarations --format sarif > tflint.sarif
       - name: Upload SARIF file
         if: success() || failure()
-        uses: github/codeql-action/upload-sarif@d186a2a36cc67bfa1b860e6170d37fb9634742c7 # v2.2.11
+        uses: github/codeql-action/upload-sarif@cdcdbb579706841c47f7063dda365e292e5cad7a # v2.13.4
         with:
           sarif_file: tflint.sarif
   tfsec:

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -31,15 +31,11 @@ jobs:
       - uses: terraform-linters/setup-tflint@19a52fbac37dacb22a09518e4ef6ee234f2d4987 # v4.0.0
         name: Setup TFLint
         with:
-          tflint_version: v0.47.0
-          tflint_wrapper: true
+          tflint_version: latest
       - name: Init TFLint
-        run: tflint --init --chdir=./
+        run: tflint --init
       - name: Run TFLint
-        run: tflint --disable-rule=terraform_unused_declarations --chdir=./ --format sarif > tflint.sarif
-      - run: echo ${{ steps.tflint.outputs.stdout }}
-      - run: echo ${{ steps.tflint.outputs.stderr }}
-      - run: echo ${{ steps.tflint.outputs.exitcode }}
+        run: tflint --disable-rule=terraform_unused_declarations --format sarif > tflint.sarif
       - name: Upload SARIF file
         if: success() || failure()
         uses: github/codeql-action/upload-sarif@cdcdbb579706841c47f7063dda365e292e5cad7a # v2.13.4

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -32,10 +32,14 @@ jobs:
         name: Setup TFLint
         with:
           tflint_version: v0.47.0
+          tflint_wrapper: true
       - name: Init TFLint
-        run: tflint --init
+        run: tflint --init --chdir=./
       - name: Run TFLint
-        run: tflint --disable-rule=terraform_unused_declarations --chdir=./ --recursive --format sarif > tflint.sarif
+        run: tflint --disable-rule=terraform_unused_declarations --chdir=./ --format sarif > tflint.sarif
+      - run: echo ${{ steps.tflint.outputs.stdout }}
+      - run: echo ${{ steps.tflint.outputs.stderr }}
+      - run: echo ${{ steps.tflint.outputs.exitcode }}
       - name: Upload SARIF file
         if: success() || failure()
         uses: github/codeql-action/upload-sarif@cdcdbb579706841c47f7063dda365e292e5cad7a # v2.13.4

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -31,11 +31,11 @@ jobs:
       - uses: terraform-linters/setup-tflint@19a52fbac37dacb22a09518e4ef6ee234f2d4987 # v4.0.0
         name: Setup TFLint
         with:
-          tflint_version: v0.44.1
+          tflint_version: v0.47.0
       - name: Init TFLint
         run: tflint --init
       - name: Run TFLint
-        run: tflint --disable-rule=terraform_unused_declarations --format sarif > tflint.sarif
+        run: tflint --disable-rule=terraform_unused_declarations --chdir=./ --recursive --format sarif > tflint.sarif
       - name: Upload SARIF file
         if: success() || failure()
         uses: github/codeql-action/upload-sarif@cdcdbb579706841c47f7063dda365e292e5cad7a # v2.13.4

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-
+permissions: {}
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -21,17 +21,18 @@ jobs:
     if: github.event_name != 'workflow_dispatch'
     steps:
     - name: Checkout
-      uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         fetch-depth: 0
     - name: Run Analysis
-      uses: ministryofjustice/github-actions/terraform-static-analysis@d9a5f75c10cd50abd5f312ab9f4bab5826e4fedf # v11
+      uses: ministryofjustice/github-actions/terraform-static-analysis@7c689fe2de15e1692f5cceceb132919ab854081c # v14
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         scan_type: single
         tfsec_exclude: AWS089, AWS099, AWS009, AWS097, AWS018
         checkov_exclude: CKV_GIT_1
+        tflint_exclude: terraform_unused_declarations
 
   terraform-static-analysis-full-scan:
     permissions:
@@ -41,14 +42,15 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     steps:
     - name: Checkout
-      uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         fetch-depth: 0
     - name: Run Analysis
-      uses: ministryofjustice/github-actions/terraform-static-analysis@d9a5f75c10cd50abd5f312ab9f4bab5826e4fedf # v11
+      uses: ministryofjustice/github-actions/terraform-static-analysis@7c689fe2de15e1692f5cceceb132919ab854081c # v14
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         scan_type: full
         tfsec_exclude: AWS089, AWS099, AWS009, AWS097, AWS018
         checkov_exclude: CKV_GIT_1
+        tflint_exclude: terraform_unused_declarations

--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ module "lambda" {
 }
 
 ```
-<!--- BEGIN_TF_DOCS --->
-<!--- END_TF_DOCS --->
 
 ## Looking for issues?
 If you're looking to raise an issue with this module, please create a new issue in the [Modernisation Platform repository](https://github.com/ministryofjustice/modernisation-platform/issues).
@@ -70,6 +68,7 @@ No modules.
 | [aws_iam_role_policy_attachment.policy_arns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.policy_from_json](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lambda_function.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_function_event_invoke_config.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_event_invoke_config) | resource |
 | [aws_lambda_permission.allowed_triggers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.combined-assume-role-policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -97,6 +96,8 @@ No modules.
 | <a name="input_reserved_concurrent_executions"></a> [reserved\_concurrent\_executions](#input\_reserved\_concurrent\_executions) | The amount of reserved concurrent executions for this Lambda Function. A value of 0 disables Lambda Function from being triggered and -1 removes any concurrency limitations. Defaults to Unreserved Concurrency Limits -1. | `number` | `-1` | no |
 | <a name="input_role_description"></a> [role\_description](#input\_role\_description) | Description of IAM role to use for Lambda Function | `string` | `null` | no |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | Name of IAM role to use for Lambda Function | `string` | `null` | no |
+| <a name="input_sns_topic_on_failure"></a> [sns\_topic\_on\_failure](#input\_sns\_topic\_on\_failure) | A json policy document is being passed into the module | `string` | `""` | no |
+| <a name="input_sns_topic_on_success"></a> [sns\_topic\_on\_success](#input\_sns\_topic\_on\_success) | A json policy document is being passed into the module | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Common tags to be used by all resources | `map(string)` | n/a | yes |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | The amount of time your Lambda Function has to run in seconds. | `number` | `3` | no |
 | <a name="input_tracing_mode"></a> [tracing\_mode](#input\_tracing\_mode) | Tracing mode of the Lambda Function. Valid value can be either PassThrough or Active. | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ No modules.
 | <a name="input_reserved_concurrent_executions"></a> [reserved\_concurrent\_executions](#input\_reserved\_concurrent\_executions) | The amount of reserved concurrent executions for this Lambda Function. A value of 0 disables Lambda Function from being triggered and -1 removes any concurrency limitations. Defaults to Unreserved Concurrency Limits -1. | `number` | `-1` | no |
 | <a name="input_role_description"></a> [role\_description](#input\_role\_description) | Description of IAM role to use for Lambda Function | `string` | `null` | no |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | Name of IAM role to use for Lambda Function | `string` | `null` | no |
-| <a name="input_sns_topic_on_failure"></a> [sns\_topic\_on\_failure](#input\_sns\_topic\_on\_failure) | A json policy document is being passed into the module | `string` | `""` | no |
-| <a name="input_sns_topic_on_success"></a> [sns\_topic\_on\_success](#input\_sns\_topic\_on\_success) | A json policy document is being passed into the module | `string` | `""` | no |
+| <a name="input_sns_topic_on_failure"></a> [sns\_topic\_on\_failure](#input\_sns\_topic\_on\_failure) | SNS topic arn for the lambda's destination on failure. | `string` | `""` | no |
+| <a name="input_sns_topic_on_success"></a> [sns\_topic\_on\_success](#input\_sns\_topic\_on\_success) | SNS topic arn for the lambda's destination on success. | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Common tags to be used by all resources | `map(string)` | n/a | yes |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | The amount of time your Lambda Function has to run in seconds. | `number` | `3` | no |
 | <a name="input_tracing_mode"></a> [tracing\_mode](#input\_tracing\_mode) | Tracing mode of the Lambda Function. Valid value can be either PassThrough or Active. | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -93,3 +93,23 @@ resource "aws_lambda_permission" "allowed_triggers" {
   principal    = try(each.value.principal, format("%s.amazonaws.com", try(each.value.service, "")))
   source_arn   = try(each.value.source_arn, null)
 }
+
+resource "aws_lambda_function_event_invoke_config" "this" {
+  count = var.sns_topic_on_success == "" && var.sns_topic_on_failure == "" ? 0 : 1
+  function_name = aws_lambda_function.this.function_name
+
+  destination_config {
+    dynamic "on_failure" {
+      for_each = var.sns_topic_on_failure != "" ? [1] : []
+      content {
+        destination = var.sns_topic_on_failure
+      }
+    }
+    dynamic "on_success" {
+      for_each = var.sns_topic_on_success != "" ? [1] : []
+      content {
+        destination = var.sns_topic_on_success
+      }
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -95,7 +95,7 @@ resource "aws_lambda_permission" "allowed_triggers" {
 }
 
 resource "aws_lambda_function_event_invoke_config" "this" {
-  count = var.sns_topic_on_success == "" && var.sns_topic_on_failure == "" ? 0 : 1
+  count         = var.sns_topic_on_success == "" && var.sns_topic_on_failure == "" ? 0 : 1
   function_name = aws_lambda_function.this.function_name
 
   destination_config {

--- a/variables.tf
+++ b/variables.tf
@@ -128,13 +128,13 @@ variable "policy_json_attached" {
 }
 
 variable "sns_topic_on_failure" {
-  description = "A json policy document is being passed into the module"
+  description = "SNS topic arn for the lambda's destination on failure."
   type        = string
   default     = ""
 }
 
 variable "sns_topic_on_success" {
-  description = "A json policy document is being passed into the module"
+  description = "SNS topic arn for the lambda's destination on success."
   type        = string
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -98,10 +98,12 @@ variable "tracing_mode" {
   type        = string
   default     = null
 }
+
 variable "tags" {
   type        = map(string)
   description = "Common tags to be used by all resources"
 }
+
 variable "application_name" {
   type        = string
   description = "Name of application"
@@ -120,9 +122,19 @@ variable "memory_size" {
 }
 
 variable "policy_json_attached" {
-
   description = "A json policy document is being passed into the module"
   type        = bool
   default     = false
+}
 
+variable "sns_topic_on_failure" {
+  description = "A json policy document is being passed into the module"
+  type        = string
+  default     = ""
+}
+
+variable "sns_topic_on_success" {
+  description = "A json policy document is being passed into the module"
+  type        = string
+  default     = ""
 }


### PR DESCRIPTION
This PR is to implement https://github.com/ministryofjustice/modernisation-platform/issues/2722.

This is to allow passing of topic arns for destination config of a lambda function to allow for alerting on failure/success using SNS topics.

The change is backwards compatible.

This has been run locally with terraform plan using the instance scheduller code. This plans out OK.